### PR TITLE
Added support for core-metadata test suite for non-docker environment…

### DIFF
--- a/README_Instructions.md
+++ b/README_Instructions.md
@@ -8,19 +8,19 @@ This is main script which will be triggered from pipeline.
 
 user will need to run script as below from pipeline
 
-sh trigger.sh --service functionalTest/V2-API/<service_name> --auth <username/password> --port <port_number> --module <module> --ip <IP_address>
+sh trigger.sh --service functionalTest/V2-API/<service_name> --auth <username/password> --port <port_number> --target <target_device_under_test> --ip <IP_address>
 
    * service_name: this will be service name which is present under V2-API
    * username/password: this will be username and password of board. if user will not provide then it will
                         take default as admin/admin
-   * port: this is socket port. as of now we will take as 8002
+   * port: this is edgex client port. as of now we will take as 8002
    * module: this will be any module like KVM or STM
    * ip: this will be IP address of modue. if you give module name as KVM then there is no need to provide IP adress
 
 
 The execution flow of this script will be as follow
    1. Parse arguments
-   2. Create unique directory to store logs and data
+   2. Create unique directory to store logs and data (Here we are creating one data.txt file while deploying edgex which contains IP address of target which will needed while creating X-Auth-Token and restarting or stop any service)
    3. Check existance of virtualenv and if not exist then will create it
    4. call prerequisite_changes.py file to make changes according to service
    5. deploy edgex

--- a/README_Instructions.md
+++ b/README_Instructions.md
@@ -14,8 +14,8 @@ sh trigger.sh --service functionalTest/V2-API/<service_name> --auth <username/pa
    * username/password: this will be username and password of board. if user will not provide then it will
                         take default as admin/admin
    * port: this is edgex client port. as of now we will take as 8002
-   * module: this will be any module like KVM or STM
-   * ip: this will be IP address of modue. if you give module name as KVM then there is no need to provide IP adress
+   * target: this will be any target device like KVM or STM
+   * ip: this will be IP address of target device. if you give target name as KVM then there is no need to provide IP adress
 
 
 The execution flow of this script will be as follow

--- a/README_Instructions.md
+++ b/README_Instructions.md
@@ -1,6 +1,6 @@
-# EdgeX-TAF execution in Pipeline
+# EdgeX-TAF execution in Pipeline as well as local environment
 
-This is created as an intro to understand how EdgeX-TAF will be executed in pipeline
+This is created as an intro to understand how EdgeX-TAF will be execute in pipeline or local environment
 
 ## trigger.sh
 
@@ -30,3 +30,26 @@ The execution flow of this script will be as follow
 ## prerequisite_changes.py
 
 This file contains required modification to be done in EdgeX-TAF before execution start
+
+
+## There are some more scripts which are under TAF/utils/scripts/manual/ directory and will be use for non docker environment execution.
+
+##### 1. api-gateway-token.sh
+         In non docker mode we are using X-Auth method. So, this script is used to create X-Auth-Token with curl command. 
+         Here this script will be called while testsuite setup, teardown and execution of robot tests.
+
+##### 2. deploy-edgex.sh
+         This is first script which will be called to deploy edgex when we start execution. So basically if our target device will be KVM 
+         then it will start QEMU and set IP address of QUMU to BASE_URL in global_variables.py file. If target device will other devices 
+         then directly it will set IP address of device to BASE_URL in global_variables.py file.
+         (Note: if execution will be in local environment then remove "--yocto --conn_method=http" from this file. so line should be like 
+                "python3 px_red/target/utilities/start_kvm.py &> kvm.log &")
+
+##### 3. shutdown.sh
+         This script is the last script which will shutdown edgex and do some cleanup task.
+
+##### 4. restart-services.sh
+         This script is used to restart any micro service.
+
+##### 5. stop-services.sh
+         This script is used to stop any micro service.

--- a/README_Instructions.md
+++ b/README_Instructions.md
@@ -1,0 +1,32 @@
+# EdgeX-TAF execution in Pipeline
+
+This is created as an intro to understand how EdgeX-TAF will be executed in pipeline
+
+## trigger.sh
+
+This is main script which will be triggered from pipeline.
+
+user will need to run script as below from pipeline
+
+sh trigger.sh --service functionalTest/V2-API/<service_name> --auth <username/password> --port <port_number> --module <module> --ip <IP_address>
+
+   * service_name: this will be service name which is present under V2-API
+   * username/password: this will be username and password of board. if user will not provide then it will
+                        take default as admin/admin
+   * port: this is socket port. as of now we will take as 8002
+   * module: this will be any module like KVM or STM
+   * ip: this will be IP address of modue. if you give module name as KVM then there is no need to provide IP adress
+
+
+The execution flow of this script will be as follow
+   1. Parse arguments
+   2. Create unique directory to store logs and data
+   3. Check existance of virtualenv and if not exist then will create it
+   4. call prerequisite_changes.py file to make changes according to service
+   5. deploy edgex
+   6. start run test suite and save logs under unique directory
+   7. shutdown edgex
+
+## prerequisite_changes.py
+
+This file contains required modification to be done in EdgeX-TAF before execution start

--- a/TAF/utils/scripts/manual/api-gateway-token.sh
+++ b/TAF/utils/scripts/manual/api-gateway-token.sh
@@ -1,4 +1,4 @@
-# This script will generate X-Auth-Token from Swagger login
+# This script will generate X-Auth-Token
 
 #!/bin/bash
 

--- a/TAF/utils/scripts/manual/api-gateway-token.sh
+++ b/TAF/utils/scripts/manual/api-gateway-token.sh
@@ -1,0 +1,33 @@
+# This script will generate X-Auth-Token from Swagger login
+
+#!/bin/bash
+
+option=${1}
+BASE_URL=`cat ${DATA_DIR}/data.txt`
+
+if [ -z "$AUTH" ]
+then
+    username="admin"
+    password="admin"
+else
+    username=`echo ${AUTH} |cut -d/ -f 1`
+    password=`echo ${AUTH} |cut -d/ -f 2`
+fi
+
+port=${PORT}
+
+case ${option} in
+  -useradd)  #create user
+    if [ -z "$token" ]
+    then
+        token=`curl -s -X POST "https://${BASE_URL}:${port}/login" -H  "accept: application/json" -H  "X-Original-IP: ${BASE_URL}" -H  "Content-Type: application/json" -d "{\"username\":\"${username}\",\"password\":\"${password}\"}" --insecure | jq -r .token`
+        echo ${token}
+    else
+        echo ${token}
+    fi
+  ;;
+  -userdel)  #delete user
+    token=''
+    echo ${token}
+  ;;
+esac

--- a/TAF/utils/scripts/manual/deploy-edgex.sh
+++ b/TAF/utils/scripts/manual/deploy-edgex.sh
@@ -1,0 +1,39 @@
+# This script is to deploy KVM and get IP address of qemu
+
+#!/bin/bash
+
+GLOBAL_VAR_DIR=${WORK_DIR}/TAF/config/global_variables.py
+
+if [ ${MODULE} ==  "KVM" ] || [ ${MODULE} ==  "kvm" ]
+then
+    cd ${WORK_DIR}/../edge-linux-test-pytest
+    python3 -m pip install -r ${HOME}/edge-linux-test-pytest/requirements.txt
+
+    if [ -f kvm_data.json ]
+    then
+        echo "#################"
+        echo "KVM is already up"
+        echo "#################"
+    else
+        if [ -f ${DATA_DIR}/data.txt ]
+        then
+            rm ${DATA_DIR}/data.txt
+        fi
+
+        python3 px_red/target/utilities/start_kvm.py --yocto --conn_method=http &> kvm.log &
+
+        while [ ! -f kvm_data.json ]
+        do
+            sleep 1
+        done
+
+        ip=`jq '.ip_address' kvm_data.json`
+        echo ${ip} >> ${DATA_DIR}/data.txt
+        sed 's/.//;s/.$//' ${DATA_DIR}/data.txt > ${DATA_DIR}/data1.txt
+        mv ${DATA_DIR}/data1.txt ${DATA_DIR}/data.txt
+        sed -i '0,/BASE_URL = .*/ s//BASE_URL = '$ip'/' $GLOBAL_VAR_DIR
+    fi
+else
+    ip=`cat ${DATA_FILE}`
+    sed -i '0,/BASE_URL = .*/ s//BASE_URL = "'$ip'"/' $GLOBAL_VAR_DIR
+fi

--- a/TAF/utils/scripts/manual/deploy-edgex.sh
+++ b/TAF/utils/scripts/manual/deploy-edgex.sh
@@ -4,12 +4,13 @@
 
 GLOBAL_VAR_DIR=${WORK_DIR}/TAF/config/global_variables.py
 
-if [ ${MODULE} ==  "KVM" ] || [ ${MODULE} ==  "kvm" ]
+if [ ${TARGET} ==  "KVM" ] || [ ${TARGET} ==  "kvm" ]
 then
     cd ${WORK_DIR}/../edge-linux-test-pytest
+    echo "<<<<< Installing pytest related libraries >>>>>"
     python3 -m pip install -r ${HOME}/edge-linux-test-pytest/requirements.txt
 
-    if [ -f kvm_data.json ]
+    if ps ax | grep -v grep | grep start_kvm.py > /dev/null
     then
         echo "#################"
         echo "KVM is already up"

--- a/TAF/utils/scripts/manual/restart-services.sh
+++ b/TAF/utils/scripts/manual/restart-services.sh
@@ -1,1 +1,20 @@
+# This script is to restart any service
+
 #!/bin/sh
+
+BASE_URL=`cat ${DATA_DIR}/data.txt`
+SERVICE=$1
+
+if [ -z "$AUTH" ]
+then
+    username="admin"
+    password="admin"
+else
+    username=`echo ${AUTH} |cut -d/ -f 1`
+    password=`echo ${AUTH} |cut -d/ -f 2`
+fi
+
+echo ${password} > ${DATA_DIR}/password.txt
+sshpass -f ${DATA_DIR}/password.txt ssh -t ${username}@${BASE_URL} 'echo ${password}|sudo -S systemctl restart '${SERVICE}''
+sleep 2
+rm ${DATA_DIR}/password.txt

--- a/TAF/utils/scripts/manual/shutdown.sh
+++ b/TAF/utils/scripts/manual/shutdown.sh
@@ -8,7 +8,8 @@ GLOBAL_VAR_DIR=${WORK_DIR}/TAF/config/global_variables.py
 if [ -f kvm_data.json ]
 then
     pid=`jq '.pid' kvm_data.json`
-    kill -2 ${pid}
+    # currently we are using kill -9 but would prefer kill -2 in the future
+    kill -9 ${pid}
     result=`echo $?`
 
     if [ $result = "1" ]

--- a/TAF/utils/scripts/manual/shutdown.sh
+++ b/TAF/utils/scripts/manual/shutdown.sh
@@ -1,1 +1,21 @@
+# This script is to shutdown edgex after executing test cases
+
 #!/bin/sh
+
+cd ${WORK_DIR}/../edge-linux-test-pytest
+GLOBAL_VAR_DIR=${WORK_DIR}/TAF/config/global_variables.py
+
+if [ -f kvm_data.json ]
+then
+    pid=`jq '.pid' kvm_data.json`
+    kill -9 ${pid}
+    rm kvm_data.json
+
+    sed -i '0,/BASE_URL = .*/ s//BASE_URL = ""/' $GLOBAL_VAR_DIR
+else
+    echo ""
+    echo "###################"
+    echo "KVM is already down"
+    echo "###################"
+    echo ""
+fi

--- a/TAF/utils/scripts/manual/shutdown.sh
+++ b/TAF/utils/scripts/manual/shutdown.sh
@@ -8,10 +8,17 @@ GLOBAL_VAR_DIR=${WORK_DIR}/TAF/config/global_variables.py
 if [ -f kvm_data.json ]
 then
     pid=`jq '.pid' kvm_data.json`
-    kill -9 ${pid}
-    rm kvm_data.json
+    kill -2 ${pid}
+    result=`echo $?`
 
-    sed -i '0,/BASE_URL = .*/ s//BASE_URL = ""/' $GLOBAL_VAR_DIR
+    if [ $result = "1" ]
+    then
+        echo "<<<< Edgex shutdown failed >>>>"
+    else
+        rm kvm_data.json
+        sed -i '0,/BASE_URL = .*/ s//BASE_URL = ""/' $GLOBAL_VAR_DIR
+        echo "<<<< Edgex shutdown successfully >>>>"
+    fi
 else
     echo ""
     echo "###################"

--- a/TAF/utils/scripts/manual/stop-services.sh
+++ b/TAF/utils/scripts/manual/stop-services.sh
@@ -1,1 +1,20 @@
+# This script is to stop any service
+
 #!/bin/sh
+
+BASE_URL=`cat ${DATA_DIR}/data.txt`
+SERVICE=$1
+
+if [ -z "$AUTH" ]
+then
+    username="admin"
+    password="admin"
+else
+    username=`echo ${AUTH} |cut -d/ -f 1`
+    password=`echo ${AUTH} |cut -d/ -f 2`
+fi
+
+echo ${password} > ${DATA_DIR}/password.txt
+sshpass -f ${DATA_DIR}/password.txt ssh -t ${username}@${BASE_URL} 'echo ${password}|sudo -S systemctl stop '${SERVICE}''
+sleep 2
+rm ${DATA_DIR}/password.txt

--- a/prerequisite_changes.py
+++ b/prerequisite_changes.py
@@ -105,10 +105,9 @@ def general_changes():
              "def check_service_startup(d, token):",
              "    SettingsInfo().constant.BASE_URL=open(os.getenv(\"DATA_FILE\"), \"r\").read()\n    SettingsInfo().constant.BASE_URL=SettingsInfo("
              ").constant.BASE_URL[:-1]" + "\n")
-    if target == "KVM" or target == "kvm":
-        add_data("TAF/testCaseModules/keywords/common/commonKeywords.robot",
-                 "Set suite variable  ${response}  ${resp.status_code}",
-                 "    Set suite variable  ${body}  ${resp.json()}\n")
+    add_data("TAF/testCaseModules/keywords/common/commonKeywords.robot",
+             "Set suite variable  ${response}  ${resp.status_code}",
+             "    Set suite variable  ${body}  ${resp.json()}\n")
 
 
 def main():
@@ -117,55 +116,54 @@ def main():
         # This is core-metadata service specific changes
         change_auth_type("TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot")
         change_port("8443/core-metadata", "8002/metadata")
-        if target == "KVM" or target == "kvm":
-            # add a variable in GET-Positive.robot file which contain response device length
-            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
-                     "When Query All Devices\n",
-                     "    ${length}=    Get Length    $body[device]\n")
-            # add a variable in GET-Positive.robot file which contain response object length with offset as 2
-            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
-                     "When Query All Devices With offset=2\n",
-                     "    ${length}=    Get Length    $body[object]\n")
-            # Replacing device count 7 with velue of variable length in GET-Positive.robot file
-            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
-                    "== 7",
-                    "== ${length}")
-            # Replacing device count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
-            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
-                    "== 5",
-                    "== ${length}-2")
-            # add a variable in GET-Positive.robot file which contain response device profile length
-            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
-                     "When Query All Device Profiles\n",
-                     "    ${length}=    Get Length    $body[profiles]\n")
-            # add a variable in GET-Positive.robot file which contain response object length with offset as 2
-            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
-                     "When Query All Device Profiles With offset=2\n",
-                     "    ${length}=    Get Length    $body[object]\n")
-            # Replacing device profile count 8 with velue of variable length in GET-Positive.robot file
-            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
-                    "== 8",
-                    "== ${length}")
-            # Replacing device profile count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
-            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
-                    "== 6",
-                    "== ${length}")
-            # add a variable in GET-Positive.robot file which contain response device service length
-            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
-                     "When Query All Device Services\n",
-                     "    ${length}=    Get Length    $body[object]\n")
-            # add a variable in GET-Positive.robot file which contain response object length with offset as 2
-            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
-                     "When Query All Device Services With offset=2\n",
-                     "    ${length}=    Get Length    $body[object]\n")
-            # Replacing device service count 6 with velue of variable length in GET-Positive.robot file
-            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
-                    "== 6",
-                    "== ${length}-2")
-            # Replacing device service count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
-            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
-                    "== 4",
-                    "== ${length}-4")
+        # add a variable in GET-Positive.robot file which contain response device length
+        add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                 "When Query All Devices\n",
+                 "    ${length}=    Get Length    ${body}[devices]\n")
+        # add a variable in GET-Positive.robot file which contain response object length with offset as 2
+        add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                 "When Query All Devices With offset=2\n",
+                 "    ${length}=    Get Length    ${body}[devices]\n")
+        # Replacing device count 7 with velue of variable length in GET-Positive.robot file
+        replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                "== 7",
+                "== ${length}")
+        # Replacing device count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
+        replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                "== 5",
+                "== ${length}")
+        # add a variable in GET-Positive.robot file which contain response device profile length
+        add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                 "When Query All Device Profiles\n",
+                 "    ${length}=    Get Length    ${body}[profiles]\n")
+        # add a variable in GET-Positive.robot file which contain response object length with offset as 2
+        add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                 "When Query All Device Profiles With offset=2\n",
+                 "    ${length}=    Get Length    ${body}[profiles]\n")
+        # Replacing device profile count 8 with velue of variable length in GET-Positive.robot file
+        replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                "== 8",
+                "== ${length}")
+        # Replacing device profile count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
+        replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                "== 6",
+                "== ${length}")
+        # add a variable in GET-Positive.robot file which contain response device service length
+        add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                 "When Query All Device Services\n",
+                 "    ${length}=    Get Length    ${body}[services]\n")
+        # add a variable in GET-Positive.robot file which contain response object length with offset as 2
+        add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                 "When Query All Device Services With offset=2\n",
+                 "    ${length}=    Get Length    ${body}[services]\n")
+        # Replacing device service count 6 with velue of variable length in GET-Positive.robot file
+        replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                "== 6",
+                "== ${length}")
+        # Replacing device service count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
+        replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                "== 4",
+                "== ${length}")
     if service == "core-data":
         # TBD
         print("This is core-data service related changes")

--- a/prerequisite_changes.py
+++ b/prerequisite_changes.py
@@ -1,0 +1,166 @@
+# This file is for making modification in EdgeX-TAF tests
+
+import sys
+import fileinput
+
+service = sys.argv[1]
+module = sys.argv[2]
+
+
+def swap(f_path, search_str, new_str):
+    with fileinput.FileInput(f_path, inplace=True) as file:
+        for line in file:
+            if line == search_str:
+                print(new_str, end='\n')
+            else:
+                print(line, end='')
+
+
+def global_variable(file_path):
+    """
+    will do below action
+        1. find BASE_URL from global_variables.py file and
+           give default value as ""
+            - if BASE_URL variable is not available then it will stop execution
+        2. find DEPLOY_TYPE from global_variables.py file and set it
+           as a generic which will set value from environment
+            - if DEPLOY_TYPE variable is not available then it will
+              stop execution
+    """
+    with open(file_path, 'r') as file:
+        content = file.read()
+        assert "BASE_URL" in content, print("-----BASE_URL does not exist in global_variables.py-----")
+        swap(file_path, "BASE_URL = \"localhost\"\n", "BASE_URL = \"\"")
+        assert "DEPLOY_TYPE" in content, print("-----DEPLOY_TYPE does not exist in global_variables.py-----")
+        swap(file_path,
+             "DEPLOY_TYPE = \"docker\"\n",
+             "DEPLOY_TYPE = os.getenv(\"DEPLOY_TYPE\")")
+
+
+def change_auth_type(file_path):
+    """
+    will change auth type from "Authorization=Bearer" to "X-Auth-Token"
+    in whole file as in manual mode we are using X-Auth-Token method
+    """
+    with open(file_path, 'r') as f:
+        newlines = []
+        for line in f.readlines():
+            newlines.append(line.replace('Authorization=Bearer ${jwt_token}',
+                                         'X-Auth-Token=${jwt_token}'))
+    with open(file_path, 'w') as f:
+        for line in newlines:
+            f.write(line)
+
+
+def add_data(file_path, find, new_line):
+    """
+    will do below action
+        1. will put specific line (i.e. new_line) in file.
+    """
+    with open(file_path, "r") as in_file:
+        buf = in_file.readlines()
+    with open(file_path, "w") as out_file:
+        for line in buf:
+            if find in line:
+                line = line + new_line
+            out_file.write(line)
+
+
+def change_port(old_port, new_port):
+    """
+    Will replace port in global_variables.py file
+    """
+    with open('TAF/config/global_variables.py', 'rt') as f:
+        newlines = []
+        for line in f.readlines():
+            newlines.append(line.replace(old_port, new_port))
+    with open('TAF/config/global_variables.py', 'w') as f:
+        for line in newlines:
+            f.write(line)
+
+
+def replace(file_path, old_str, new_str):
+    with open(file_path, 'rt') as f:
+        newlines = []
+        for line in f.readlines():
+            newlines.append(line.replace(old_str, new_str))
+    with open(file_path, 'w') as f:
+        for line in newlines:
+            f.write(line)
+
+
+def general_changes():
+    """
+    Note: This function will do below task
+        1. will modify "BASE_URL", "DEPLOY_TYPE" and "PORT <core-metadata> "
+        2. will change Auth type in common files
+        3. set IP address of qemu to "BASE_URL"
+    """
+    global_variable("TAF/config/global_variables.py")
+    change_auth_type("TAF/testCaseModules/keywords/setup/startup_checker.py")
+    change_auth_type("TAF/testCaseModules/keywords/common/commonKeywords.robot")
+    add_data("TAF/testCaseModules/keywords/setup/startup_checker.py",
+             "import subprocess", "import os" + "\n")
+    add_data("TAF/testCaseModules/keywords/setup/startup_checker.py",
+             "def check_service_startup(d, token):",
+             "    SettingsInfo().constant.BASE_URL=open(os.getenv(\"DATA_FILE\"), \"r\").read()\n    SettingsInfo().constant.BASE_URL=SettingsInfo("
+             ").constant.BASE_URL[:-1]" + "\n")
+    if module == "KVM" or module == "kvm":
+        add_data("TAF/testCaseModules/keywords/common/commonKeywords.robot",
+                 "Set suite variable  ${response}  ${resp.status_code}",
+                 "    Set suite variable  ${body}  ${resp.json()}\n")
+
+
+def main():
+    general_changes()
+    if service == "core-metadata":
+        # This is core-metadata service specific changes
+        change_auth_type("TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot")
+        change_port("8443/core-metadata", "8002/metadata")
+        if module == "KVM" or module == "kvm":
+            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                     "When Query All Devices\n",
+                     "    ${length}=    Get Length    $body[device]\n")
+            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                     "When Query All Devices With offset=2\n",
+                     "    ${length}=    Get Length    $body[object]\n")
+            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                    "== 7",
+                    "== ${length}")
+            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
+                    "== 5",
+                    "== ${length}-2")
+            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                     "When Query All Device Profiles\n",
+                     "    ${length}=    Get Length    $body[profiles]\n")
+            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                     "When Query All Device Profiles With offset=2\n",
+                     "    ${length}=    Get Length    $body[object]\n")
+            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                    "== 8",
+                    "== ${length}")
+            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
+                    "== 6",
+                    "== ${length}")
+            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                     "When Query All Device Services\n",
+                     "    ${length}=    Get Length    $body[object]\n")
+            add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                     "When Query All Device Services With offset=2\n",
+                     "    ${length}=    Get Length    $body[object]\n")
+            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                    "== 6",
+                    "== ${length}-2")
+            replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
+                    "== 4",
+                    "== ${length}-4")
+    if service == "core-data":
+        # TBD
+        print("This is core-data service related changes")
+    if service == "core-command":
+        # TBD
+        print("This is core-command service related changes")
+
+
+if __name__ == "__main__":
+    main()

--- a/prerequisite_changes.py
+++ b/prerequisite_changes.py
@@ -4,7 +4,7 @@ import sys
 import fileinput
 
 service = sys.argv[1]
-module = sys.argv[2]
+target = sys.argv[2]
 
 
 def swap(f_path, search_str, new_str):
@@ -105,7 +105,7 @@ def general_changes():
              "def check_service_startup(d, token):",
              "    SettingsInfo().constant.BASE_URL=open(os.getenv(\"DATA_FILE\"), \"r\").read()\n    SettingsInfo().constant.BASE_URL=SettingsInfo("
              ").constant.BASE_URL[:-1]" + "\n")
-    if module == "KVM" or module == "kvm":
+    if target == "KVM" or target == "kvm":
         add_data("TAF/testCaseModules/keywords/common/commonKeywords.robot",
                  "Set suite variable  ${response}  ${resp.status_code}",
                  "    Set suite variable  ${body}  ${resp.json()}\n")
@@ -117,40 +117,52 @@ def main():
         # This is core-metadata service specific changes
         change_auth_type("TAF/testCaseModules/keywords/core-metadata/coreMetadataAPI.robot")
         change_port("8443/core-metadata", "8002/metadata")
-        if module == "KVM" or module == "kvm":
+        if target == "KVM" or target == "kvm":
+            # add a variable in GET-Positive.robot file which contain response device length
             add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
                      "When Query All Devices\n",
                      "    ${length}=    Get Length    $body[device]\n")
+            # add a variable in GET-Positive.robot file which contain response object length with offset as 2
             add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
                      "When Query All Devices With offset=2\n",
                      "    ${length}=    Get Length    $body[object]\n")
+            # Replacing device count 7 with velue of variable length in GET-Positive.robot file
             replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
                     "== 7",
                     "== ${length}")
+            # Replacing device count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
             replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/device/GET-Positive.robot",
                     "== 5",
                     "== ${length}-2")
+            # add a variable in GET-Positive.robot file which contain response device profile length
             add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
                      "When Query All Device Profiles\n",
                      "    ${length}=    Get Length    $body[profiles]\n")
+            # add a variable in GET-Positive.robot file which contain response object length with offset as 2
             add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
                      "When Query All Device Profiles With offset=2\n",
                      "    ${length}=    Get Length    $body[object]\n")
+            # Replacing device profile count 8 with velue of variable length in GET-Positive.robot file
             replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
                     "== 8",
                     "== ${length}")
+            # Replacing device profile count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
             replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceprofile/GET-Positive.robot",
                     "== 6",
                     "== ${length}")
+            # add a variable in GET-Positive.robot file which contain response device service length
             add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
                      "When Query All Device Services\n",
                      "    ${length}=    Get Length    $body[object]\n")
+            # add a variable in GET-Positive.robot file which contain response object length with offset as 2
             add_data("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
                      "When Query All Device Services With offset=2\n",
                      "    ${length}=    Get Length    $body[object]\n")
+            # Replacing device service count 6 with velue of variable length in GET-Positive.robot file
             replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
                     "== 6",
                     "== ${length}-2")
+            # Replacing device service count 5 with velue of variable length with offset as 2 in GET-Positive.robot file
             replace("TAF/testScenarios/functionalTest/V2-API/core-metadata/deviceservice/GET-Positive.robot",
                     "== 4",
                     "== ${length}-4")

--- a/requirements_eaton.txt
+++ b/requirements_eaton.txt
@@ -1,0 +1,6 @@
+robotframework
+requests
+robotframework-requests
+robotframework-jsonlibrary
+wheel
+pyyaml

--- a/requirements_eaton.txt
+++ b/requirements_eaton.txt
@@ -1,6 +1,0 @@
-robotframework
-requests
-robotframework-requests
-robotframework-jsonlibrary
-wheel
-pyyaml

--- a/trigger.sh
+++ b/trigger.sh
@@ -19,7 +19,7 @@
 if [ $# -eq 0 ]
 then
     echo "No arguments supplied, please provide data"
-    echo "Usage: sh trigger.sh --service functionalTest/V2-API/<any_service> --auth <username/password> --port <port_number> --target <Target_module> --ip <ip_address>"
+    echo "Usage: sh trigger.sh --service functionalTest/V2-API/<any_service> --auth <username/password> --port <port_number> --target <Target_device> --ip <ip_address>"
     exit 1
 fi
 
@@ -108,20 +108,22 @@ then
 fi
 
 # creating VENV if it does not exist
-if [[ "$VIRTUAL_ENV" != " " ]]
+if [ ! -d "env_taf" ]
 then
     echo "=============="
     echo "creating VENV"
     echo "=============="
-    python3 -m venv .
-    source ./bin/activate
+    python3 -m venv env_taf
+    source env_taf/bin/activate
     python3 -m pip install -U pip
-    pip3 install -U virtualenv
+else
+    source env_taf/bin/activate
+    python3 -m pip install -U pip
 fi
 
 # Install Robot Framework related Libraries
 echo "<<<<< Installing Robot framework related libraries >>>>>"
-python3 -m pip install -r requirements_eaton.txt
+pip3 install -r requirements.txt
 sleep 1
 
 # Install TAF common:
@@ -131,7 +133,7 @@ sleep 1
 
 # Install dependency lib
 echo "<<<<< Installing TAF common related libraries >>>>>"
-python3 -m pip install -r ./edgex-taf-common/requirements.txt
+pip3 install -r ./edgex-taf-common/requirements.txt
 
 # Install edgex-taf-common as lib
 pip3 install ./edgex-taf-common

--- a/trigger.sh
+++ b/trigger.sh
@@ -118,7 +118,6 @@ then
     python3 -m pip install -U pip
 else
     source env_taf/bin/activate
-    python3 -m pip install -U pip
 fi
 
 # Install Robot Framework related Libraries

--- a/trigger.sh
+++ b/trigger.sh
@@ -137,8 +137,12 @@ pip3 install -r ./edgex-taf-common/requirements.txt
 # Install edgex-taf-common as lib
 pip3 install ./edgex-taf-common
 
-# Change general modification as well as service specific modification for test execution
-python3 prerequisite_changes.py ${test_service} ${target}
+if [ ! -f ${WORK_DIR}/working_dir/status.txt ]
+then
+    # Change general modification as well as service specific modification for test execution
+    python3 prerequisite_changes.py ${test_service} ${target}
+    echo done > ${WORK_DIR}/working_dir/status.txt
+fi
 
 result=`echo $?`
 

--- a/trigger.sh
+++ b/trigger.sh
@@ -1,0 +1,172 @@
+# This is main script to trigger edgex-taf tests in non-docker mode in pipeline
+#	usage for KVM: sh trigger.sh --service functionalTest/V2-API/core-metadata --auth admin/admin --port 8002 --module KVM
+#	usage for STM: sh trigger.sh --service functionalTest/V2-API/core-metadata --auth admin/admin --port 8002 --module STM --ip <IP_address_of_STM>
+#
+# This script workflow will be like
+#       1. Parse arguments
+#              Note: if you will set module as KVM then no need to give IP address
+#       2. Create unique directory to store logs and data
+#	3. Check existance of virtualenv and if not exist then will create it.
+#       4. call prerequisite_changes.py file to make changes according to service
+#       5. deploy edgex
+#       6. start run test suite and save logs under unique directory
+#       7. shutdown edgex
+#
+# Note: After completion of test execution log report will be saved in working_dir/
+
+#!/bin/bash
+
+if [ $# -eq 0 ]
+then
+    echo "No arguments supplied, please provide data"
+    echo "Usage: sh trigger.sh --service functionalTest/V2-API/<any_service> --auth <username/password> --port <port_number> --module <module> --ip <ip_address>"
+    exit 1
+fi
+
+SHORT=s:,a:,p:,m:,i:
+LONG=service:,auth:,port:,module:,ip:
+OPTS=$(getopt -a -n weather --options $SHORT --longoptions $LONG -- "$@")
+
+eval set -- "$OPTS"
+
+while :
+do
+  case "$1" in
+    -s | --service )
+      service="$2"
+      shift 2
+      ;;
+    -a | --auth )
+      auth="$2"
+      shift 2
+      ;;
+    -p | --port)
+      port=$2
+      shift 2
+      ;;
+    -m | --module)
+      module=$2
+      shift 2
+      ;;
+    -i | --ip)
+      ip=$2
+      shift 2
+      ;;
+    --)
+      shift;
+      break
+      ;;
+    *)
+      echo "Unexpected option: $1"
+      ;;
+  esac
+done
+
+# parsing service name from functionalTest/V2-API/<core-service>
+test_service=`echo $service | awk -F"/" '{print $NF}'`
+service_flag=0
+
+service_list=(core-data
+              core-metadata
+              core-command
+              app-serice
+              support-notifications
+              support-schedular
+              system-agent
+             )
+
+for str in ${service_list[@]}; do
+  if [ $str == $test_service ]
+  then
+      service_flag=1
+  fi
+done
+
+if [ $service_flag == 0 ]
+then
+    echo "Please provice valid service"
+    exit 1
+fi
+
+#creating one timestamp based directory to store data
+data_dir=$(date +%y%m%d_%H%M%S)
+mkdir -p working_dir/${data_dir}
+
+# export some variables before starting execution
+export WORK_DIR=`pwd`
+export DATA_DIR=${WORK_DIR}/working_dir/${data_dir}
+export DATA_FILE=${DATA_DIR}/data.txt
+export SECURITY_SERVICE_NEEDED=true
+export DEPLOY_TYPE=manual
+export AUTH=${auth}
+export PORT=${port}
+export MODULE=${module}
+
+if [ $module == "STM" ] || [ $module == "stm" ]
+then
+    echo $ip > $DATA_FILE
+fi
+
+# creating VENV if it does not exist
+if [[ "$VIRTUAL_ENV" != " " ]]
+then
+    echo "=============="
+    echo "creating VENV"
+    echo "=============="
+    python3 -m venv .
+    source ./bin/activate
+    python3 -m pip install -U pip
+    pip install -U virtualenv
+fi
+
+# Install Robot Framework related Libraries
+python3 -m pip install robotframework
+python3 -m pip install requests
+python3 -m pip install robotframework-requests
+python3 -m pip install robotframework-jsonlibrary
+
+# Install TAF common:
+git clone https://github.com/edgexfoundry/edgex-taf-common.git
+
+# Install dependency lib
+pip3 install wheel
+python3 -m pip install -r ./edgex-taf-common/requirements.txt
+pip3 install pyyaml
+
+# Install edgex-taf-common as lib
+pip3 install ./edgex-taf-common
+
+# Change general modification as well as service specific modification for test execution
+python3 prerequisite_changes.py ${test_service} ${module}
+
+result=`echo $?`
+
+if [ $result = "1" ]
+then
+    exit 1
+fi
+
+# Deploy edgex
+python3 -m TUC --exclude Skipped --include deploy-base-service -u deploy.robot -p default
+
+while [ ! -f ${DATA_DIR}/data.txt ]
+do
+    sleep 1
+done
+
+# Start test case execution
+python3 -m TUC --exclude Skipped -t $service -p default
+
+while [ ! -f TAF/testArtifacts/reports/edgex/log.html ]
+do
+   sleep 1
+done
+
+# saving logs
+cp TAF/testArtifacts/reports/edgex/log.html ${DATA_DIR}
+
+# Shutdown edgex
+python3 -m TUC --exclude Skipped --include shutdown-edgex -u shutdown.robot -p default
+
+# deactivate VENV
+deactivate


### PR DESCRIPTION
This PR is regarding below changes

1. Added below scripts under "TAF/utils/scripts/manual/" to execute EdgeX-TAF under non-docker environment.
    - deploy-edgex.sh: This script is to deploy KVM and get IP address
    - api-gateway-token.sh: This script is to generate X-Auth-Token
    - shutdown.sh: This script is to shutdown edgex after test execution
    - restart-service.sh: This script is to restart any service
    - stop-service.sh: This script is to stop any service
2. Added trigger,.sh script. This is our main script which will execute in our pipeline.
3. Added prerequisite_changes.py file. This file contains changes to be done before execution.
4. Added README_Instruction.md file which will help to understand how execution flow will be.